### PR TITLE
Change the default vertical alignment to baseline in HorizontalLayout

### DIFF
--- a/vaadin-ordered-layout-flow-parent/vaadin-ordered-layout-flow/src/main/java/com/vaadin/flow/component/orderedlayout/HorizontalLayout.java
+++ b/vaadin-ordered-layout-flow-parent/vaadin-ordered-layout-flow/src/main/java/com/vaadin/flow/component/orderedlayout/HorizontalLayout.java
@@ -36,10 +36,11 @@ public class HorizontalLayout extends Component implements ThemableLayout,
         FlexComponent, ClickNotifier<HorizontalLayout> {
 
     /**
-     * Constructs an empty layout with spacing on by default.
+     * Constructs an empty layout with spacing on and baseline alignment by default.
      */
     public HorizontalLayout() {
         setSpacing(true);
+        setDefaultVerticalComponentAlignment(FlexComponent.Alignment.BASELINE);
     }
 
     /**


### PR DESCRIPTION
`HorizontalLayout layout = new HorizontalLayout(emailField, subscribeButton);`

### Before:
<img width="660" alt="horizontallayout-none" src="https://github.com/user-attachments/assets/92766a31-c85d-4b6d-a081-aec34848f979">


### After:
<img width="660" alt="horizontallayout-baseline" src="https://github.com/user-attachments/assets/5ea97286-eaf2-47fc-85eb-3013e2e017f6">
